### PR TITLE
Feature/world animations

### DIFF
--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -9,8 +9,7 @@ namespace LibSWBF2
     {
 #if WIN32
         const string LIB_NAME = "LibSWBF2";
-#endif
-#if UNIX
+#else
         const string LIB_NAME = "SWBF2";
 #endif
 

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -178,6 +178,7 @@ namespace LibSWBF2
                                         out IntPtr regionArr, out int regCount, out int regInc,
                                         out IntPtr animArr, out int animCount, out int animInc,
                                         out IntPtr animGroupArr, out int animGroupCount, out int animGroupInc,
+                                        out IntPtr animHierArr, out int animHierCount, out int animHierInc,
                                         out IntPtr terrPtr);
 
         // World Animation //
@@ -195,6 +196,11 @@ namespace LibSWBF2
 
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void WorldAnimGroup_GetAnimInstPairs(IntPtr group, out IntPtr animNames, out IntPtr instNames, out int numPairs);
+
+        // World Animation Group //
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static extern bool WorldAnimHier_FetchAllFields(IntPtr hier, out IntPtr rootPtr, out IntPtr children, out int numChildren);
 
 
         // Region // 

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -7,12 +7,12 @@ namespace LibSWBF2
 
     internal static class APIWrapper
     {
-#if WIN32
-        const string LIB_NAME = "LibSWBF2";
-#endif
-#if UNIX
-        const string LIB_NAME = "libSWBF2";
-#endif
+//#if WIN32
+//        const string LIB_NAME = "LibSWBF2";
+//#endif
+//#if UNIX
+        const string LIB_NAME = "SWBF2";
+//#endif
 
         // Memory //
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
@@ -176,7 +176,17 @@ namespace LibSWBF2
         public static extern bool World_FetchAllFields(IntPtr world, out IntPtr nameOut, out IntPtr skyNameOut,
                                         out IntPtr instanceArr, out int instCount, out int instInc,
                                         out IntPtr regionArr, out int regCount, out int regInc,
+                                        out IntPtr animArr, out int animCount, out int animInc,
                                         out IntPtr terrPtr);
+
+        // World Animation //
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern bool WorldAnim_FetchAllFields(IntPtr worldAnim, out bool loop, out bool localT, out IntPtr namePtr);
+
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void WorldAnim_GetAnimKeys(IntPtr worldAnim, out IntPtr keyBuff, out int numKeys, bool IsRotation);
+
+
         // Region // 
 
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -177,6 +177,7 @@ namespace LibSWBF2
                                         out IntPtr instanceArr, out int instCount, out int instInc,
                                         out IntPtr regionArr, out int regCount, out int regInc,
                                         out IntPtr animArr, out int animCount, out int animInc,
+                                        out IntPtr animGroupArr, out int animGroupCount, out int animGroupInc,
                                         out IntPtr terrPtr);
 
         // World Animation //
@@ -185,6 +186,15 @@ namespace LibSWBF2
 
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
         public static extern void WorldAnim_GetAnimKeys(IntPtr worldAnim, out IntPtr keyBuff, out int numKeys, bool IsRotation);
+
+
+        // World Animation Group //
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.U1)]
+        public static extern bool WorldAnimGroup_FetchAllFields(IntPtr group, out bool bool0, out bool bool1, out IntPtr namePtr);
+
+        [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void WorldAnimGroup_GetAnimInstPairs(IntPtr group, out IntPtr animNames, out IntPtr instNames, out int numPairs);
 
 
         // Region // 

--- a/LibSWBF2.NET/API/APIWrapper.cs
+++ b/LibSWBF2.NET/API/APIWrapper.cs
@@ -7,12 +7,12 @@ namespace LibSWBF2
 
     internal static class APIWrapper
     {
-//#if WIN32
-//        const string LIB_NAME = "LibSWBF2";
-//#endif
-//#if UNIX
+#if WIN32
+        const string LIB_NAME = "LibSWBF2";
+#endif
+#if UNIX
         const string LIB_NAME = "SWBF2";
-//#endif
+#endif
 
         // Memory //
         [DllImport(LIB_NAME, CallingConvention = CallingConvention.Cdecl)]

--- a/LibSWBF2.NET/LibSWBF2.NET.csproj
+++ b/LibSWBF2.NET/LibSWBF2.NET.csproj
@@ -1,48 +1,69 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5A2ADCC9-C997-4A17-84FA-A759DD6E5384}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LibSWBF2</RootNamespace>
+    <AssemblyName>LibSWBF2.NET</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>WIN32</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;WIN32</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-    <Optimize>true</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;WIN32</DefineConstants>
+    <DefineConstants>TRACE;WIN32</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ProjectGuid>{5A2ADCC9-C997-4A17-84FA-A759DD6E5384}</ProjectGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\APIWrapper.cs" />
@@ -52,6 +73,7 @@
     <Compile Include="Types\Vector2.cs" />
     <Compile Include="Types\Vector3.cs" />
     <Compile Include="Types\Vector4.cs" />
+    <Compile Include="Types\WorldAnimationKey.cs" />
     <Compile Include="Types\Enums.cs" />
     <Compile Include="Wrappers\Interfaces.cs" />
     <Compile Include="Wrappers\Level.cs" />

--- a/LibSWBF2.NET/LibSWBF2.NET.csproj
+++ b/LibSWBF2.NET/LibSWBF2.NET.csproj
@@ -1,69 +1,48 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{5A2ADCC9-C997-4A17-84FA-A759DD6E5384}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>LibSWBF2</RootNamespace>
-    <AssemblyName>LibSWBF2.NET</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;WIN32</DefineConstants>
+    <DefineConstants>WIN32</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugType>portable</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+    <Optimize>true</Optimize>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;WIN32</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;WIN32</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ProjectGuid>{5A2ADCC9-C997-4A17-84FA-A759DD6E5384}</ProjectGuid>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\APIWrapper.cs" />

--- a/LibSWBF2.NET/Types/Enums.cs
+++ b/LibSWBF2.NET/Types/Enums.cs
@@ -156,4 +156,11 @@ namespace LibSWBF2.Enums
         Float,
 		String
     };
+
+    public enum EWorldAnimKeyTransitionType : byte
+    {
+        Pop = 0,
+        Linear = 1,
+        Spline = 2,
+    };
 }

--- a/LibSWBF2.NET/Types/WorldAnimationKey.cs
+++ b/LibSWBF2.NET/Types/WorldAnimationKey.cs
@@ -10,11 +10,11 @@ namespace LibSWBF2.Types
     [StructLayout(LayoutKind.Sequential, Pack=1)]
     public struct WorldAnimationKey
     {
-        float Time;
-        Vector3 Value; // For rotations this is in radians, in .ANM files they are in degrees 
-        EWorldAnimKeyTransitionType TransitionType;
-        Vector3 EaseOut;
-        Vector3 EaseIn;
+        public float Time;
+        public Vector3 Value; // For rotations this is in radians, in .ANM files they are in degrees 
+        public EWorldAnimKeyTransitionType TransitionType;
+        public Vector3 EaseOut;
+        public Vector3 EaseIn;
 
         public override String ToString()
         {

--- a/LibSWBF2.NET/Types/WorldAnimationKey.cs
+++ b/LibSWBF2.NET/Types/WorldAnimationKey.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using LibSWBF2.Types;
+using LibSWBF2.Enums;
+
+
+namespace LibSWBF2.Types
+{
+    [StructLayout(LayoutKind.Sequential, Pack=1)]
+    public struct WorldAnimationKey
+    {
+        float Time;
+        Vector3 Value; // For rotations this is in radians, in .ANM files they are in degrees 
+        EWorldAnimKeyTransitionType TransitionType;
+        Vector3 EaseOut;
+        Vector3 EaseIn;
+
+        public override String ToString()
+        {
+            return String.Format(
+                "Time: {0}, Value: {1}, TransitionType: {2}, EaseOut: {3}, EaseIn: {4}",
+                Time, Value.ToString(), TransitionType.ToString(), EaseOut.ToString(), EaseIn.ToString()
+            );
+        }
+    }
+}

--- a/LibSWBF2.NET/Wrappers/World.cs
+++ b/LibSWBF2.NET/Wrappers/World.cs
@@ -83,8 +83,8 @@ namespace LibSWBF2.Wrappers
     public sealed class WorldAnimationGroup : NativeWrapper
     {
         public string Name { get; private set; }
-        public bool Field1 { get; private set; }
-        public bool Field2 { get; private set; }
+        public bool PlaysAtStart { get; private set; }
+        public bool DisablesHierarchies { get; private set; }
 
         internal override void SetPtr(IntPtr ptr)
         {
@@ -93,8 +93,8 @@ namespace LibSWBF2.Wrappers
                                                     out IntPtr namePtr))
             {
                 Name = Marshal.PtrToStringAnsi(namePtr);
-                Field1 = f1;
-                Field2 = f2;
+                PlaysAtStart = f1;
+                DisablesHierarchies = f2;
             }
         }
 
@@ -119,8 +119,8 @@ namespace LibSWBF2.Wrappers
         {
             CheckValidity();
             return String.Format(
-                "{0}: F1? {1}, F2? {2}, Has {3} Animation-Instance pairs",
-                Name, Field1, Field2, GetAnimationInstancePairs().Count     
+                "{0}: PlaysAtStart? {1}, DisablesHierarchies? {2}, Has {3} Animation-Instance pairs",
+                Name, PlaysAtStart, DisablesHierarchies, GetAnimationInstancePairs().Count     
             );
         }
     }

--- a/LibSWBF2.NET/Wrappers/World.cs
+++ b/LibSWBF2.NET/Wrappers/World.cs
@@ -126,6 +126,32 @@ namespace LibSWBF2.Wrappers
     }
 
 
+    public sealed class WorldAnimationHierarchy : NativeWrapper
+    {
+        public string RootName { get; private set; }
+        public string[] ChildrenNames { get; private set; }
+
+        internal override void SetPtr(IntPtr ptr)
+        {
+            base.SetPtr(ptr);
+            if (APIWrapper.WorldAnimHier_FetchAllFields(ptr, out IntPtr namePtr, out IntPtr childrenBuf, out int numChildren))
+            {
+                RootName = Marshal.PtrToStringAnsi(namePtr);
+                ChildrenNames = MemUtils.IntPtrToStringList(childrenBuf, numChildren);
+            }
+        }
+
+        public override string ToString()
+        {
+            CheckValidity();
+            return String.Format(
+                "Animation Hierarchy with root {0} and {1} children",
+                RootName, ChildrenNames.Length   
+            );
+        }
+    }
+
+
 
     public sealed class World : NativeWrapper
     {
@@ -147,6 +173,9 @@ namespace LibSWBF2.Wrappers
         IntPtr animGroupArray;
         int animGroupCount, animGroupIncrement;
 
+        IntPtr animHierArray;
+        int animHierCount, animHierIncrement;
+
         internal override void SetPtr(IntPtr worldPtr)
         {
             base.SetPtr(worldPtr);
@@ -155,6 +184,7 @@ namespace LibSWBF2.Wrappers
                                         out regionArray, out regionCount, out regionIncrement,
                                         out animArray, out animCount, out animIncrement,
                                         out animGroupArray, out animGroupCount, out animGroupIncrement,
+                                        out animHierArray, out animHierCount, out animHierIncrement,
                                         out terrainPtr))
             {
                 Name = Marshal.PtrToStringAnsi(nameOut);
@@ -191,6 +221,12 @@ namespace LibSWBF2.Wrappers
         {
             CheckValidity();
             return RegisterChildren(MemUtils.IntPtrToWrapperArray<WorldAnimationGroup>(animGroupArray, animGroupCount, animGroupIncrement));
-        }    
+        }  
+
+        public WorldAnimationHierarchy[] GetAnimationHierarchies()
+        {
+            CheckValidity();
+            return RegisterChildren(MemUtils.IntPtrToWrapperArray<WorldAnimationHierarchy>(animHierArray, animHierCount, animHierIncrement));
+        }   
     }
 }

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -822,8 +822,8 @@ namespace LibSWBF2
     	nameCache = group -> GetName();
     	namePtr = nameCache.Buffer();
 
-    	bool0 = group -> GetField1();
-    	bool1 = group -> GetField2();
+    	bool0 = group -> IsPlayingAtStart();
+    	bool1 = group -> DisablesHierarchies();
 
     	return true;
     }

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -734,6 +734,7 @@ namespace LibSWBF2
 										const Region*& regionArr, int32_t& regCount, int32_t& regInc,
 										const WorldAnimation*& animArr, int32_t& animCount, int32_t& animInc,
 										const WorldAnimationGroup*& animGroupArr, int32_t& animGroupCount, int32_t& animGroupInc,
+										const WorldAnimationHierarchy*& animHierArr, int32_t& animHierCount, int32_t& animHierInc,
 										const Terrain*& terrPtr)
 	{
 		CheckPtr(world,false);
@@ -763,6 +764,11 @@ namespace LibSWBF2
 		animGroupArr = animGroups.GetArrayPtr();
 		animGroupCount = (int32_t)animGroups.Size();
 		animGroupInc = sizeof(WorldAnimationGroup);
+
+    	const List<WorldAnimationHierarchy>& animHiers = world -> GetAnimationHierarchies();
+		animHierArr = animHiers.GetArrayPtr();
+		animHierCount = (int32_t)animHiers.Size();
+		animHierInc = sizeof(WorldAnimationHierarchy);
 
 		terrPtr = world -> GetTerrain();
 
@@ -841,6 +847,26 @@ namespace LibSWBF2
 		
 		animNames = animsPtrsBuffer.GetArrayPtr();
 		instNames = instsPtrsBuffer.GetArrayPtr();
+    }
+
+
+    const uint8_t WorldAnimHier_FetchAllFields(const WorldAnimationHierarchy* hier, const char *& rootPtr, const char**& childNames, int32_t& numChildren)
+    {
+    	static String rootCache;
+    	static List<String> childrenCache;
+    	static List<const char*> childPtrsBuffer;
+    	CheckPtr(hier,false);
+
+    	rootCache = hier -> GetRootName();
+    	rootPtr = rootCache.Buffer();
+
+    	childrenCache = hier -> GetChildNames();
+    	GetStringListPtrs(childrenCache, childPtrsBuffer);
+
+    	childNames = childPtrsBuffer.GetArrayPtr();
+    	numChildren = childrenCache.Size();
+
+    	return true;
     }
 
 

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -733,6 +733,7 @@ namespace LibSWBF2
 										const Instance*& instanceArr, int32_t& instCount, int32_t& instInc,
 										const Region*& regionArr, int32_t& regCount, int32_t& regInc,
 										const WorldAnimation*& animArr, int32_t& animCount, int32_t& animInc,
+										const WorldAnimationGroup*& animGroupArr, int32_t& animGroupCount, int32_t& animGroupInc,
 										const Terrain*& terrPtr)
 	{
 		CheckPtr(world,false);
@@ -757,6 +758,11 @@ namespace LibSWBF2
 		animArr = anims.GetArrayPtr();
 		animCount = (int32_t)anims.Size();
 		animInc = sizeof(WorldAnimation);
+
+    	const List<WorldAnimationGroup>& animGroups = world -> GetAnimationGroups();
+		animGroupArr = animGroups.GetArrayPtr();
+		animGroupCount = (int32_t)animGroups.Size();
+		animGroupInc = sizeof(WorldAnimationGroup);
 
 		terrPtr = world -> GetTerrain();
 
@@ -798,6 +804,45 @@ namespace LibSWBF2
 		keyBuff = KeyCache.GetArrayPtr();
 		numKeys = KeyCache.Size();
     }
+
+
+	//Wrappers - World Animation Group
+
+    const uint8_t WorldAnimGroup_FetchAllFields(const WorldAnimationGroup* group, uint8_t& bool0, uint8_t& bool1, const char*& namePtr)
+    {
+    	static String nameCache;
+    	CheckPtr(group,false);
+
+    	nameCache = group -> GetName();
+    	namePtr = nameCache.Buffer();
+
+    	bool0 = group -> GetField1();
+    	bool1 = group -> GetField2();
+
+    	return true;
+    }
+
+    const void WorldAnimGroup_GetAnimInstPairs(const WorldAnimationGroup* group, const char**& animNames, const char**& instNames, int32_t& numPairs)
+    {
+    	static List<String> animsCache;
+    	static List<String> instsCache;
+    	static List<const char*> animsPtrsBuffer;
+    	static List<const char*> instsPtrsBuffer;
+
+    	numPairs = 0;
+    	CheckPtr(group,);
+
+    	group -> GetAnimationInstancePairs(animsCache, instsCache);
+
+		numPairs = (int32_t)animsCache.Size();
+
+		GetStringListPtrs(animsCache, animsPtrsBuffer);
+		GetStringListPtrs(instsCache, instsPtrsBuffer);
+		
+		animNames = animsPtrsBuffer.GetArrayPtr();
+		instNames = instsPtrsBuffer.GetArrayPtr();
+    }
+
 
     
 	// Wrappers - Script

--- a/LibSWBF2/API.cpp
+++ b/LibSWBF2/API.cpp
@@ -732,6 +732,7 @@ namespace LibSWBF2
 	const uint8_t World_FetchAllFields(const World* world, const char*&nameOut, const char*&skyNameOut,
 										const Instance*& instanceArr, int32_t& instCount, int32_t& instInc,
 										const Region*& regionArr, int32_t& regCount, int32_t& regInc,
+										const WorldAnimation*& animArr, int32_t& animCount, int32_t& animInc,
 										const Terrain*& terrPtr)
 	{
 		CheckPtr(world,false);
@@ -752,10 +753,51 @@ namespace LibSWBF2
 		regCount = (int32_t)regions.Size();
 		regInc = sizeof(Region);
 
+    	const List<WorldAnimation>& anims = world -> GetAnimations();
+		animArr = anims.GetArrayPtr();
+		animCount = (int32_t)anims.Size();
+		animInc = sizeof(WorldAnimation);
+
 		terrPtr = world -> GetTerrain();
 
 		return true;
 	}
+
+
+	//Wrappers - World Animation
+
+	const uint8_t WorldAnim_FetchAllFields(const WorldAnimation* anim, uint8_t& loop, uint8_t& localT, const char*& namePtr)
+	{
+		static String nameCache;
+		CheckPtr(anim,false);
+
+		loop = anim -> IsLooping();
+		localT = anim -> IsTranslationLocal();
+
+		nameCache = anim -> GetName();
+		namePtr = nameCache.Buffer();
+		
+		return true;
+	}
+
+    const void WorldAnim_GetAnimKeys(const WorldAnimation* anim, WorldAnimationKey*& keyBuff, int32_t& numKeys, uint8_t IsRotation)
+    {
+    	static List<WorldAnimationKey> KeyCache;
+    	numKeys = 0;
+		CheckPtr(anim,);
+
+		if (IsRotation)
+		{
+			KeyCache = anim -> GetRotationKeys();
+		}
+		else 
+		{
+			KeyCache = anim -> GetPositionKeys();
+		}
+
+		keyBuff = KeyCache.GetArrayPtr();
+		numKeys = KeyCache.Size();
+    }
 
     
 	// Wrappers - Script

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -25,6 +25,7 @@ namespace LibSWBF2
 		struct Joint;
 		class EntityClass;
 		class Script;
+		class WorldAnimation;
 		class World;
 		class Texture;
 		class Config;
@@ -43,6 +44,7 @@ namespace LibSWBF2
 		struct Vector3;
 		struct Vector4;
 		struct Vector2;
+		struct WorldAnimationKey;
 	}
 
 	using namespace Wrappers;
@@ -166,7 +168,13 @@ namespace LibSWBF2
 		LIBSWBF2_API const uint8_t World_FetchAllFields(const World* world, const char*&nameOut, const char*&skyNameOut,
 										const Instance*& instanceArr, int32_t& instCount, int32_t& instInc,
 										const Region*& regionArr, int32_t& regCount, int32_t& regInc,
+										const WorldAnimation*& animArr, int32_t& animCount, int32_t& animInc,
 										const Terrain*& terrPtr);
+
+		// Wrappers - WorldAnimation
+		LIBSWBF2_API const uint8_t WorldAnim_FetchAllFields(const WorldAnimation* anim, uint8_t& loop, uint8_t& localT, const char*& namePtr);
+        LIBSWBF2_API const void WorldAnim_GetAnimKeys(const WorldAnimation* anim, WorldAnimationKey*& keyBuff, int32_t& numKeys, uint8_t IsRotation);
+
 
 		// Wrappers - Script
 		LIBSWBF2_API const char* Script_GetName(const Script* script);

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -25,6 +25,7 @@ namespace LibSWBF2
 		struct Joint;
 		class EntityClass;
 		class Script;
+		class WorldAnimationGroup;
 		class WorldAnimation;
 		class World;
 		class Texture;
@@ -169,11 +170,17 @@ namespace LibSWBF2
 										const Instance*& instanceArr, int32_t& instCount, int32_t& instInc,
 										const Region*& regionArr, int32_t& regCount, int32_t& regInc,
 										const WorldAnimation*& animArr, int32_t& animCount, int32_t& animInc,
+										const WorldAnimationGroup*& animGroupArr, int32_t& animGroupCount, int32_t& animGroupInc,
 										const Terrain*& terrPtr);
 
 		// Wrappers - WorldAnimation
 		LIBSWBF2_API const uint8_t WorldAnim_FetchAllFields(const WorldAnimation* anim, uint8_t& loop, uint8_t& localT, const char*& namePtr);
         LIBSWBF2_API const void WorldAnim_GetAnimKeys(const WorldAnimation* anim, WorldAnimationKey*& keyBuff, int32_t& numKeys, uint8_t IsRotation);
+
+		// Wrappers - WorldAnimationGroup
+		LIBSWBF2_API const uint8_t WorldAnimGroup_FetchAllFields(const WorldAnimationGroup* group, uint8_t& bool0, uint8_t& bool1, const char*& namePtr);
+        LIBSWBF2_API const void WorldAnimGroup_GetAnimInstPairs(const WorldAnimationGroup* group, const char**& animNames, const char**& instNames, int32_t& numKeys);
+
 
 
 		// Wrappers - Script

--- a/LibSWBF2/API.h
+++ b/LibSWBF2/API.h
@@ -26,6 +26,7 @@ namespace LibSWBF2
 		class EntityClass;
 		class Script;
 		class WorldAnimationGroup;
+		class WorldAnimationHierarchy;
 		class WorldAnimation;
 		class World;
 		class Texture;
@@ -171,6 +172,7 @@ namespace LibSWBF2
 										const Region*& regionArr, int32_t& regCount, int32_t& regInc,
 										const WorldAnimation*& animArr, int32_t& animCount, int32_t& animInc,
 										const WorldAnimationGroup*& animGroupArr, int32_t& animGroupCount, int32_t& animGroupInc,
+										const WorldAnimationHierarchy*& animHierArr, int32_t& animHierCount, int32_t& animHierInc,
 										const Terrain*& terrPtr);
 
 		// Wrappers - WorldAnimation
@@ -181,6 +183,8 @@ namespace LibSWBF2
 		LIBSWBF2_API const uint8_t WorldAnimGroup_FetchAllFields(const WorldAnimationGroup* group, uint8_t& bool0, uint8_t& bool1, const char*& namePtr);
         LIBSWBF2_API const void WorldAnimGroup_GetAnimInstPairs(const WorldAnimationGroup* group, const char**& animNames, const char**& instNames, int32_t& numKeys);
 
+		// Wrappers - WorldAnimationHierarchy
+    	LIBSWBF2_API const uint8_t WorldAnimHier_FetchAllFields(const WorldAnimationHierarchy* hier, const char *& rootPtr, const char**& childNames, int32_t& numChildren);
 
 
 		// Wrappers - Script

--- a/LibSWBF2/CMakeLists.txt
+++ b/LibSWBF2/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(LibSWBF2 PRIVATE
   "${PROJECT_SOURCE_DIR}/Types/Vector3.cpp"
   "${PROJECT_SOURCE_DIR}/Types/Vector3u8.cpp"
   "${PROJECT_SOURCE_DIR}/Types/Vector4.cpp"
+  "${PROJECT_SOURCE_DIR}/Types/WorldAnimationKey.cpp"
 
   # Wrappers
   "${PROJECT_SOURCE_DIR}/Wrappers/AnimationBank.cpp"
@@ -200,6 +201,8 @@ target_sources(LibSWBF2 PRIVATE
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/wrld.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/wrld.INFO.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/XFRM.cpp"
+  "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/WorldAnimKeyChunk.cpp"
+  "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anim.INFO.cpp"
 
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/zaa_/BIN_.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/zaa_/MINA.cpp"

--- a/LibSWBF2/CMakeLists.txt
+++ b/LibSWBF2/CMakeLists.txt
@@ -195,6 +195,7 @@ target_sources(LibSWBF2 PRIVATE
 
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anim.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anmg.cpp"
+  "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anmh.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/inst.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/regn.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/SIZE.cpp"
@@ -204,6 +205,7 @@ target_sources(LibSWBF2 PRIVATE
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/WorldAnimKeyChunk.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anim.INFO.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anmg.INFO.cpp"
+  "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anmh.INFO.cpp"
 
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/zaa_/BIN_.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/zaa_/MINA.cpp"

--- a/LibSWBF2/CMakeLists.txt
+++ b/LibSWBF2/CMakeLists.txt
@@ -203,6 +203,7 @@ target_sources(LibSWBF2 PRIVATE
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/XFRM.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/WorldAnimKeyChunk.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anim.INFO.cpp"
+  "${PROJECT_SOURCE_DIR}/Chunks/LVL/wrld/anmg.INFO.cpp"
 
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/zaa_/BIN_.cpp"
   "${PROJECT_SOURCE_DIR}/Chunks/LVL/zaa_/MINA.cpp"

--- a/LibSWBF2/Chunks/BaseChunk.cpp
+++ b/LibSWBF2/Chunks/BaseChunk.cpp
@@ -151,15 +151,15 @@ namespace LibSWBF2::Chunks
 		return m_ChunkPosition + sizeof(ChunkHeader) + sizeof(ChunkSize);
 	}
 
-	bool BaseChunk::PositionInChunk(const size_t& CurrentPosition)
+	bool BaseChunk::PositionInChunk(const size_t& PossiblePosition)
 	{
 		size_t dataPosition = GetDataPosition();
-		return CurrentPosition >= dataPosition && CurrentPosition < dataPosition + m_Size;
+		return PossiblePosition >= dataPosition && PossiblePosition < dataPosition + m_Size;
 	}
 
 	bool BaseChunk::ThereIsAnother(FileReader& stream)
 	{
-		return stream.GetFileSize() - stream.GetPosition() >= 8 && PositionInChunk(stream.GetPosition() + 8);
+		return stream.GetFileSize() - stream.GetPosition() >= 8 && PositionInChunk(stream.GetPosition() + 7);
 	}
 
 	bool BaseChunk::SkipChunk(FileReader& stream, const bool& printWarn)

--- a/LibSWBF2/Chunks/GenericChunk.cpp
+++ b/LibSWBF2/Chunks/GenericChunk.cpp
@@ -411,6 +411,5 @@ namespace LibSWBF2::Chunks
 	template struct LIBSWBF2_API GenericChunk<"MINA"_m>;
 	template struct LIBSWBF2_API GenericChunk<"TNJA"_m>;
 	template struct LIBSWBF2_API GenericChunk<"TADA"_m>;
-
 }
 

--- a/LibSWBF2/Chunks/GenericChunk.cpp
+++ b/LibSWBF2/Chunks/GenericChunk.cpp
@@ -352,6 +352,7 @@ namespace LibSWBF2::Chunks
 	template struct LIBSWBF2_API GenericChunk<"wrld"_m>;
 	template struct LIBSWBF2_API GenericChunk<"regn"_m>;
 	template struct LIBSWBF2_API GenericChunk<"anmg"_m>;
+	template struct LIBSWBF2_API GenericChunk<"anmh"_m>;
 	template struct LIBSWBF2_API GenericChunk<"anim"_m>;
 	template struct LIBSWBF2_API GenericChunk<"POSK"_m>;
 	template struct LIBSWBF2_API GenericChunk<"ROTK"_m>;

--- a/LibSWBF2/Chunks/GenericChunk.cpp
+++ b/LibSWBF2/Chunks/GenericChunk.cpp
@@ -352,6 +352,7 @@ namespace LibSWBF2::Chunks
 	template struct LIBSWBF2_API GenericChunk<"wrld"_m>;
 	template struct LIBSWBF2_API GenericChunk<"regn"_m>;
 	template struct LIBSWBF2_API GenericChunk<"anmg"_m>;
+	template struct LIBSWBF2_API GenericChunk<"NOHI"_m>;
 	template struct LIBSWBF2_API GenericChunk<"anmh"_m>;
 	template struct LIBSWBF2_API GenericChunk<"anim"_m>;
 	template struct LIBSWBF2_API GenericChunk<"POSK"_m>;

--- a/LibSWBF2/Chunks/LVL/wrld/WorldAnimKeyChunk.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/WorldAnimKeyChunk.cpp
@@ -1,0 +1,42 @@
+#include "pch.h"
+#include "WorldAnimKeyChunk.h"
+#include "InternalHelpers.h"
+#include "FileReader.h"
+
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+	template<uint32_t Header>
+	void WorldAnimKeyChunk<Header>::RefreshSize()
+	{
+		THROW("Not implemented!");
+	}
+
+	template<uint32_t Header>
+	void WorldAnimKeyChunk<Header>::WriteToStream(FileWriter& stream)
+	{
+		THROW("Not implemented!");
+	}
+
+	template<uint32_t Header>
+	void WorldAnimKeyChunk<Header>::ReadFromStream(FileReader& stream)
+	{
+		BaseChunk::ReadFromStream(stream);
+		GenericChunk<Header>::Check(stream);
+			
+    	m_Key.ReadFromStream(stream);
+
+		BaseChunk::EnsureEnd(stream);
+	}
+
+	template<uint32_t Header>
+	String WorldAnimKeyChunk<Header>::ToString() const
+	{
+		return m_Key.ToString();
+	}
+
+
+	template struct LIBSWBF2_API WorldAnimKeyChunk<0>;
+	template struct LIBSWBF2_API WorldAnimKeyChunk<"POSK"_m>;
+	template struct LIBSWBF2_API WorldAnimKeyChunk<"ROTK"_m>;
+}

--- a/LibSWBF2/Chunks/LVL/wrld/WorldAnimKeyChunk.h
+++ b/LibSWBF2/Chunks/LVL/wrld/WorldAnimKeyChunk.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Chunks/GenericChunk.h"
+#include "Types/WorldAnimationKey.h"
+
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+	template<uint32_t Header>
+	struct LIBSWBF2_API WorldAnimKeyChunk : public GenericChunk<Header>
+	{
+		Types::WorldAnimationKey m_Key;
+
+		void RefreshSize() override;
+		void WriteToStream(FileWriter& stream) override;
+		void ReadFromStream(FileReader& stream) override;
+
+		String ToString() const override;
+	};
+
+	struct LIBSWBF2_API WorldAnimKeyChunkNC : public WorldAnimKeyChunk<0> {};
+	struct LIBSWBF2_API POSK : public WorldAnimKeyChunk<"POSK"_m> {};
+	struct LIBSWBF2_API ROTK : public WorldAnimKeyChunk<"ROTK"_m> {};
+}

--- a/LibSWBF2/Chunks/LVL/wrld/anim.INFO.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anim.INFO.cpp
@@ -1,0 +1,41 @@
+#include "pch.h"
+#include "anim.INFO.h"
+#include "InternalHelpers.h"
+#include "FileReader.h"
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+    void anim_INFO::RefreshSize()
+    {
+        THROW("Not implemented!");
+    }
+
+    void anim_INFO::WriteToStream(FileWriter& stream)
+    {
+        THROW("Not implemented!");
+    }
+
+    void anim_INFO::ReadFromStream(FileReader& stream)
+    {
+        BaseChunk::ReadFromStream(stream);
+        Check(stream);
+
+        m_Name = stream.ReadString();
+
+        m_RunTime = stream.ReadFloat();
+        m_Looping = stream.ReadByte();
+        m_LocalTranslation = stream.ReadByte();
+
+        BaseChunk::EnsureEnd(stream);
+    }
+
+    String anim_INFO::ToString() const
+    {
+        String rep = fmt::format("Name: {}, Run Time: {}, Is Looping: {}, Transition Is Local: {}", 
+                        m_Name, 
+                        m_RunTime,
+                        m_Looping == 1,
+                        m_LocalTranslation == 1).c_str();
+        return rep;
+    }
+}

--- a/LibSWBF2/Chunks/LVL/wrld/anim.INFO.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anim.INFO.h
@@ -1,20 +1,23 @@
 #pragma once
 #include "Chunks/GenericChunk.h"
-#include "anim.INFO.h"
-#include "WorldAnimKeyChunk.h"
 
 
 namespace LibSWBF2::Chunks::LVL::wrld
 {
-	struct LIBSWBF2_API anim : public GenericChunk<"anim"_m>
+	struct LIBSWBF2_API anim_INFO : public GenericChunk<"INFO"_m>
 	{
-		anim_INFO* p_Info;
+	public:
 
-		List<POSK *> m_PositionKeys;
-		List<ROTK *> m_RotationKeys;
+		String m_Name;
+		
+		float m_RunTime;
+		uint8_t m_Looping;
+		uint8_t m_LocalTranslation;
 
 		void RefreshSize() override;
 		void WriteToStream(FileWriter& stream) override;
 		void ReadFromStream(FileReader& stream) override;
+		
+		String ToString() const override;
 	};
 }

--- a/LibSWBF2/Chunks/LVL/wrld/anim.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anim.cpp
@@ -1,8 +1,11 @@
 #include "pch.h"
 #include "anim.h"
+//#include "anim.INFO.h"
 #include "Logging/Logger.h"
 #include "InternalHelpers.h"
 #include "FileReader.h"
+//#include "Chunks/LVL/wrld/WorldAnimKeyChunk.h"
+
 
 namespace LibSWBF2::Chunks::LVL::wrld
 {

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.cpp
@@ -22,18 +22,18 @@ namespace LibSWBF2::Chunks::LVL::wrld
 
         m_Name = stream.ReadString();
 
-        m_0 = stream.ReadByte();
-        m_1 = stream.ReadByte();
+        m_PlayAtStart = stream.ReadByte();
+        m_DisableHierarchy = stream.ReadByte();
 
         BaseChunk::EnsureEnd(stream);
     }
 
     String anmg_INFO::ToString() const
     {
-        String rep = fmt::format("Name: {}, Field1: {}, Field2: {}", 
+        String rep = fmt::format("Name: {}, Is Played At Start? {}, Disables Hierarchy? {}", 
                         m_Name, 
-                        m_0 == 1,
-                        m_1 == 1).c_str();
+                        m_PlayAtStart == 1,
+                        m_DisableHierarchy == 1).c_str();
         return rep;
     }
 }

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.cpp
@@ -23,17 +23,17 @@ namespace LibSWBF2::Chunks::LVL::wrld
         m_Name = stream.ReadString();
 
         m_PlayAtStart = stream.ReadByte();
-        m_DisableHierarchy = stream.ReadByte();
+        m_StopOnControl = stream.ReadByte();
 
         BaseChunk::EnsureEnd(stream);
     }
 
     String anmg_INFO::ToString() const
     {
-        String rep = fmt::format("Name: {}, Is Played At Start? {}, Disables Hierarchy? {}", 
+        String rep = fmt::format("Name: {}, Is Played At Start? {}, Disabled When Controlled? {}", 
                         m_Name, 
                         m_PlayAtStart == 1,
-                        m_DisableHierarchy == 1).c_str();
+                        m_StopOnControl == 1).c_str();
         return rep;
     }
 }

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.cpp
@@ -1,0 +1,39 @@
+#include "pch.h"
+#include "anmg.INFO.h"
+#include "InternalHelpers.h"
+#include "FileReader.h"
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+    void anmg_INFO::RefreshSize()
+    {
+        THROW("Not implemented!");
+    }
+
+    void anmg_INFO::WriteToStream(FileWriter& stream)
+    {
+        THROW("Not implemented!");
+    }
+
+    void anmg_INFO::ReadFromStream(FileReader& stream)
+    {
+        BaseChunk::ReadFromStream(stream);
+        Check(stream);
+
+        m_Name = stream.ReadString();
+
+        m_0 = stream.ReadByte();
+        m_1 = stream.ReadByte();
+
+        BaseChunk::EnsureEnd(stream);
+    }
+
+    String anmg_INFO::ToString() const
+    {
+        String rep = fmt::format("Name: {}, Field1: {}, Field2: {}", 
+                        m_Name, 
+                        m_0 == 1,
+                        m_1 == 1).c_str();
+        return rep;
+    }
+}

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.h
@@ -10,8 +10,8 @@ namespace LibSWBF2::Chunks::LVL::wrld
 
 		String m_Name;
 		
-		uint8_t m_0;
-		uint8_t m_1;
+		uint8_t m_PlayAtStart;
+		uint8_t m_DisableHierarchy;
 
 		void RefreshSize() override;
 		void WriteToStream(FileWriter& stream) override;

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.h
@@ -1,21 +1,22 @@
 #pragma once
 #include "Chunks/GenericChunk.h"
-#include "Chunks/STRMULT.h"
+
 
 namespace LibSWBF2::Chunks::LVL::wrld
 {
-	struct anmg_INFO;
-
-	struct LIBSWBF2_API anmg : public GenericChunk<"anmg"_m>
+	struct LIBSWBF2_API anmg_INFO : public GenericChunk<"INFO"_m>
 	{
 	public:
 
-		anmg_INFO *p_Info;
-
-		List<STRMULT<"ANIM"_m> *> m_AnimObjectPairs;
+		String m_Name;
+		
+		uint8_t m_0;
+		uint8_t m_1;
 
 		void RefreshSize() override;
 		void WriteToStream(FileWriter& stream) override;
 		void ReadFromStream(FileReader& stream) override;
+		
+		String ToString() const override;
 	};
 }

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.INFO.h
@@ -11,7 +11,7 @@ namespace LibSWBF2::Chunks::LVL::wrld
 		String m_Name;
 		
 		uint8_t m_PlayAtStart;
-		uint8_t m_DisableHierarchy;
+		uint8_t m_StopOnControl;
 
 		void RefreshSize() override;
 		void WriteToStream(FileWriter& stream) override;

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.cpp
@@ -5,6 +5,7 @@
 #include "InternalHelpers.h"
 #include "FileReader.h"
 
+
 namespace LibSWBF2::Chunks::LVL::wrld
 {
     void anmg::RefreshSize()
@@ -32,6 +33,10 @@ namespace LibSWBF2::Chunks::LVL::wrld
             else if (next == "ANIM"_h)
             {
                 READ_CHILD(stream, m_AnimObjectPairs.Emplace());
+            }
+            else if (next == "NOHI"_h)
+            {
+                READ_CHILD(stream, p_NoHierarchy);
             }
             else
             {

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.cpp
@@ -1,5 +1,6 @@
 #include "pch.h"
 #include "anmg.h"
+#include "anmg.INFO.h"
 #include "Logging/Logger.h"
 #include "InternalHelpers.h"
 #include "FileReader.h"

--- a/LibSWBF2/Chunks/LVL/wrld/anmg.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anmg.h
@@ -14,6 +14,8 @@ namespace LibSWBF2::Chunks::LVL::wrld
 
 		List<STRMULT<"ANIM"_m> *> m_AnimObjectPairs;
 
+		GenericChunk<"NOHI"_m> * p_NoHierarchy; 
+
 		void RefreshSize() override;
 		void WriteToStream(FileWriter& stream) override;
 		void ReadFromStream(FileReader& stream) override;

--- a/LibSWBF2/Chunks/LVL/wrld/anmh.INFO.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmh.INFO.cpp
@@ -46,10 +46,10 @@ namespace LibSWBF2::Chunks::LVL::wrld
         }
         else 
         {
-            String rep = fmt::format("Root: {} ", m_Name).c_str();   
+            String rep = fmt::format("Root: {} ", m_RootName).c_str();   
             for (int i = 0; i < m_ChildNames.Size(); i++)
             {
-                rep = rep + fmt::format("\n  Child {0}: {1}", i, m_ChildNames[i]).c_str()
+                rep = rep + fmt::format("\n  Child {0}: {1}", i, m_ChildNames[i]).c_str();
             }  
 
             return rep;       

--- a/LibSWBF2/Chunks/LVL/wrld/anmh.INFO.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmh.INFO.cpp
@@ -1,0 +1,58 @@
+#include "pch.h"
+#include "anmh.INFO.h"
+#include "InternalHelpers.h"
+#include "FileReader.h"
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+    void anmh_INFO::RefreshSize()
+    {
+        THROW("Not implemented!");
+    }
+
+    void anmh_INFO::WriteToStream(FileWriter& stream)
+    {
+        THROW("Not implemented!");
+    }
+
+    void anmh_INFO::ReadFromStream(FileReader& stream)
+    {
+        BaseChunk::ReadFromStream(stream);
+        Check(stream);
+
+        m_NumStrings = stream.ReadByte();
+
+        for (int i = 0; i < (int) m_NumStrings; i++)
+        {
+            String newStr = stream.ReadString();
+            if (i == 0)
+            {
+                m_RootName = newStr;
+            }
+            else 
+            {
+                m_ChildNames.Add(newStr);
+            }
+        }
+
+        BaseChunk::EnsureEnd(stream);
+    }
+
+    String anmh_INFO::ToString() const
+    {
+        if (m_NumStrings == 0)
+        {
+            return "Empty Hierarchy";
+        }
+        else 
+        {
+            String rep = fmt::format("Root: {} ", m_Name).c_str();   
+            for (int i = 0; i < m_ChildNames.Size(); i++)
+            {
+                rep = rep + fmt::format("\n  Child {0}: {1}", i, m_ChildNames[i]).c_str()
+            }  
+
+            return rep;       
+        }
+    }
+}

--- a/LibSWBF2/Chunks/LVL/wrld/anmh.INFO.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anmh.INFO.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "Chunks/GenericChunk.h"
+
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+	struct LIBSWBF2_API anmh_INFO : public GenericChunk<"INFO"_m>
+	{
+	public:
+
+		uint8_t m_NumStrings;
+
+		String m_RootName;
+		List<String> m_ChildNames;
+
+		void RefreshSize() override;
+		void WriteToStream(FileWriter& stream) override;
+		void ReadFromStream(FileReader& stream) override;
+		
+		String ToString() const override;
+	};
+}

--- a/LibSWBF2/Chunks/LVL/wrld/anmh.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/anmh.cpp
@@ -1,0 +1,40 @@
+#include "pch.h"
+#include "anmh.h"
+#include "anmh.INFO.h"
+#include "Logging/Logger.h"
+#include "InternalHelpers.h"
+#include "FileReader.h"
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+    void anmh::RefreshSize()
+    {
+        THROW("Not implemented!");
+    }
+
+    void anmh::WriteToStream(FileWriter& stream)
+    {
+        THROW("Not implemented!");
+    }
+
+    void anmh::ReadFromStream(FileReader& stream)
+    {
+        BaseChunk::ReadFromStream(stream);
+        Check(stream);
+
+		while (ThereIsAnother(stream))
+		{
+            ChunkHeader next = stream.ReadChunkHeader(true);
+            if (next == "INFO"_h)
+            {
+                READ_CHILD(stream, p_Info);
+            }
+            else
+            {
+                READ_CHILD_GENERIC(stream);
+            }
+		}
+
+        BaseChunk::EnsureEnd(stream);
+    }
+}

--- a/LibSWBF2/Chunks/LVL/wrld/anmh.h
+++ b/LibSWBF2/Chunks/LVL/wrld/anmh.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Chunks/GenericChunk.h"
+
+namespace LibSWBF2::Chunks::LVL::wrld
+{
+	struct anmh_INFO;
+
+	struct LIBSWBF2_API anmh : public GenericChunk<"anmh"_m>
+	{
+	public:
+
+		anmh_INFO *p_Info;
+
+		void RefreshSize() override;
+		void WriteToStream(FileWriter& stream) override;
+		void ReadFromStream(FileReader& stream) override;
+	};
+}

--- a/LibSWBF2/Chunks/LVL/wrld/wrld.cpp
+++ b/LibSWBF2/Chunks/LVL/wrld/wrld.cpp
@@ -55,6 +55,10 @@ namespace LibSWBF2::Chunks::LVL::wrld
 			{
 				READ_CHILD(stream, m_AnimationGroups.Emplace());
 			}
+			else if (nextHead == "anmh"_h)
+			{
+				READ_CHILD(stream, m_AnimationHierarchies.Emplace());
+			}
 			else
 			{
 				READ_CHILD_GENERIC(stream);

--- a/LibSWBF2/Chunks/LVL/wrld/wrld.h
+++ b/LibSWBF2/Chunks/LVL/wrld/wrld.h
@@ -6,6 +6,7 @@
 #include "regn.h"
 #include "anmg.h"
 #include "anim.h"
+#include "anmh.h"
 
 
 namespace LibSWBF2::Chunks::LVL::wrld
@@ -24,6 +25,7 @@ namespace LibSWBF2::Chunks::LVL::wrld
 
 		List<anim*> m_Animations;
 		List<anmg*> m_AnimationGroups;
+		List<anmh*> m_AnimationHierarchies;
 
 	public:
 		void RefreshSize() override;

--- a/LibSWBF2/Types/Enums.cpp
+++ b/LibSWBF2/Types/Enums.cpp
@@ -370,6 +370,22 @@ namespace LibSWBF2
 				return fmt::format("Unknown ELoadStatus: {}", (int)type).c_str();
 		}
 	}
+
+	Types::String WorldAnimKeyTransitionTypeToString(EWorldAnimKeyTransitionType type)
+	{
+		switch (type)
+		{
+			case EWorldAnimKeyTransitionType::Pop:
+				return "Pop";
+			case EWorldAnimKeyTransitionType::Linear:
+				return "Linear";		
+			case EWorldAnimKeyTransitionType::Spline:
+				return "Spline";
+			default:
+				return fmt::format("Unknown EWorldAnimKeyTransitionType: {}", (uint8_t)type).c_str();
+		}
+	}
+
 	
 	EMaterialFlags operator &(EMaterialFlags lhs, EMaterialFlags rhs)
 	{
@@ -452,10 +468,13 @@ namespace LibSWBF2
 		return static_cast<std::underlying_type<ECollisionMaskFlags>::type>(lhs) != rhs;
 	}
 
-
-
 	bool operator ==(EConfigType lhs, std::underlying_type<EConfigType>::type rhs)
 	{
 		return static_cast<std::underlying_type<EConfigType>::type>(lhs) == rhs;
+	}
+
+	bool operator ==(EWorldAnimKeyTransitionType lhs, std::underlying_type<EWorldAnimKeyTransitionType>::type rhs)
+	{
+		return static_cast<std::underlying_type<EWorldAnimKeyTransitionType>::type>(lhs) == rhs;
 	}
 }

--- a/LibSWBF2/Types/Enums.h
+++ b/LibSWBF2/Types/Enums.h
@@ -126,6 +126,13 @@ namespace LibSWBF2
 		PosZ = 6,
 	};
 
+	enum class EWorldAnimKeyTransitionType : uint8_t
+	{
+		Pop = 0,
+		Linear = 1,
+		Spline = 2,
+	};
+
 	enum class ECollisionPrimitiveType : uint32_t
 	{
 		Sphere = 1,//can also be 0...
@@ -217,6 +224,8 @@ namespace LibSWBF2
 	Types::String LIBSWBF2_API CollisionMaskTypeToString(ECollisionMaskFlags type);
 	Types::String LIBSWBF2_API CollisionPrimitiveTypeToString(ECollisionPrimitiveType type);
 	Types::String LIBSWBF2_API LoadStatusToString(ELoadStatus type);
+	Types::String LIBSWBF2_API WorldAnimKeyTransitionTypeToString(EWorldAnimKeyTransitionType type);
+
 
 	EMaterialFlags LIBSWBF2_API operator &(EMaterialFlags lhs, EMaterialFlags rhs);
 	bool LIBSWBF2_API operator ==(EMaterialFlags lhs, std::underlying_type<EMaterialFlags>::type rhs);
@@ -237,4 +246,5 @@ namespace LibSWBF2
 
 	bool LIBSWBF2_API operator ==(EConfigType lhs, std::underlying_type<EConfigType>::type rhs);
 
+	bool LIBSWBF2_API operator ==(EWorldAnimKeyTransitionType lhs, std::underlying_type<EWorldAnimKeyTransitionType>::type rhs);
 }

--- a/LibSWBF2/Types/Enums.h
+++ b/LibSWBF2/Types/Enums.h
@@ -114,18 +114,6 @@ namespace LibSWBF2
         Flag = 32,
 	};
 
-	enum class ECurveType : uint32_t
-	{
-		RotX = 0,
-		RotY = 1,
-		RotZ = 2,
-		RotW = 3,
-
-		PosX = 4,
-		PosY = 5,
-		PosZ = 6,
-	};
-
 	enum class EWorldAnimKeyTransitionType : uint8_t
 	{
 		Pop = 0,

--- a/LibSWBF2/Types/List.cpp
+++ b/LibSWBF2/Types/List.cpp
@@ -575,6 +575,7 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Wrappers::Instance>;
 	template class LIBSWBF2_API Types::List<Wrappers::Region>;
 	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimation>;
+	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimationGroup>;
 	template class LIBSWBF2_API Types::List<Wrappers::Script>;
 	template class LIBSWBF2_API Types::List<Wrappers::Sound>;
 	template class LIBSWBF2_API Types::List<Wrappers::Localization>;

--- a/LibSWBF2/Types/List.cpp
+++ b/LibSWBF2/Types/List.cpp
@@ -578,7 +578,7 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Wrappers::Region>;
 	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimation>;
 	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimationGroup>;
-	//template class LIBSWBF2_API Types::List<Wrappers::WorldAnimationHierarchy>;
+	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimationHierarchy>;
 	template class LIBSWBF2_API Types::List<Wrappers::Script>;
 	template class LIBSWBF2_API Types::List<Wrappers::Sound>;
 	template class LIBSWBF2_API Types::List<Wrappers::Localization>;

--- a/LibSWBF2/Types/List.cpp
+++ b/LibSWBF2/Types/List.cpp
@@ -458,6 +458,7 @@ namespace LibSWBF2::Types
 #include "Chunks/LVL/wrld/regn.h"
 #include "Chunks/LVL/wrld/anim.h"
 #include "Chunks/LVL/wrld/anmg.h"
+#include "Chunks/LVL/wrld/anmh.h"
 #include "Chunks/LVL/tern/PTCH.h"
 #include "Chunks/LVL/scr_/scr_.h"
 
@@ -514,6 +515,7 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<LVL::wrld::inst*>;
     template class LIBSWBF2_API Types::List<LVL::wrld::regn*>;
    	template class LIBSWBF2_API Types::List<LVL::wrld::anmg*>;
+   	template class LIBSWBF2_API Types::List<LVL::wrld::anmh*>;
     template class LIBSWBF2_API Types::List<LVL::wrld::anim*>;
     template class LIBSWBF2_API Types::List<LVL::wrld::POSK*>;
     template class LIBSWBF2_API Types::List<LVL::wrld::ROTK*>;
@@ -576,6 +578,7 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Wrappers::Region>;
 	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimation>;
 	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimationGroup>;
+	//template class LIBSWBF2_API Types::List<Wrappers::WorldAnimationHierarchy>;
 	template class LIBSWBF2_API Types::List<Wrappers::Script>;
 	template class LIBSWBF2_API Types::List<Wrappers::Sound>;
 	template class LIBSWBF2_API Types::List<Wrappers::Localization>;

--- a/LibSWBF2/Types/List.cpp
+++ b/LibSWBF2/Types/List.cpp
@@ -491,9 +491,6 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Animation>;
 	template class LIBSWBF2_API Types::List<WorldAnimationKey>;
 
-	//template class LIBSWBF2_API Types::List<Key<uint16_t>>;
-	//template class LIBSWBF2_API Types::List<Key<float_t>>;
-
 	template class LIBSWBF2_API Types::List<BoneFrames>;
 	template class LIBSWBF2_API Types::List<Polygon>;
 	template class LIBSWBF2_API Types::List<VertexWeights>;
@@ -577,7 +574,7 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Wrappers::Terrain>;
 	template class LIBSWBF2_API Types::List<Wrappers::Instance>;
 	template class LIBSWBF2_API Types::List<Wrappers::Region>;
-	//template class LIBSWBF2_API Types::List<Wrappers::WorldAnimation>;
+	template class LIBSWBF2_API Types::List<Wrappers::WorldAnimation>;
 	template class LIBSWBF2_API Types::List<Wrappers::Script>;
 	template class LIBSWBF2_API Types::List<Wrappers::Sound>;
 	template class LIBSWBF2_API Types::List<Wrappers::Localization>;

--- a/LibSWBF2/Types/List.cpp
+++ b/LibSWBF2/Types/List.cpp
@@ -436,6 +436,7 @@ namespace LibSWBF2::Types
 #include "Chunks/MSH/SEGM.h"
 #include "Chunks/MSH/MATD.h"
 #include "Chunks/MSH/MODL.h"
+#include "WorldAnimationKey.h"
 
 #include "Chunks/LVL/common/SCOP.h"
 #include "Chunks/LVL/common/DATA.h"
@@ -464,6 +465,8 @@ namespace LibSWBF2::Types
 
 #include "Chunks/GenericChunk.h"
 
+#include "Chunks/LVL/wrld/WorldAnimKeyChunk.h"
+
 #include "Wrappers/Wrappers.h"
 
 #include "DirectX/D3D9FORMAT.h"
@@ -471,7 +474,7 @@ namespace LibSWBF2::Types
 namespace LibSWBF2
 {
 	using namespace Chunks;
-	using namespace Types; //Clangfix
+	using namespace Types;
 
 	template class LIBSWBF2_API Types::List<const char*>;
 	template class LIBSWBF2_API Types::List<uint8_t>;
@@ -486,9 +489,10 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Color4u8>;
 	template class LIBSWBF2_API Types::List<String>;
 	template class LIBSWBF2_API Types::List<Animation>;
+	template class LIBSWBF2_API Types::List<WorldAnimationKey>;
 
-	template class LIBSWBF2_API Types::List<Key<uint16_t>>;
-	template class LIBSWBF2_API Types::List<Key<float_t>>;
+	//template class LIBSWBF2_API Types::List<Key<uint16_t>>;
+	//template class LIBSWBF2_API Types::List<Key<float_t>>;
 
 	template class LIBSWBF2_API Types::List<BoneFrames>;
 	template class LIBSWBF2_API Types::List<Polygon>;
@@ -514,6 +518,8 @@ namespace LibSWBF2
     template class LIBSWBF2_API Types::List<LVL::wrld::regn*>;
    	template class LIBSWBF2_API Types::List<LVL::wrld::anmg*>;
     template class LIBSWBF2_API Types::List<LVL::wrld::anim*>;
+    template class LIBSWBF2_API Types::List<LVL::wrld::POSK*>;
+    template class LIBSWBF2_API Types::List<LVL::wrld::ROTK*>;
 	template class LIBSWBF2_API Types::List<LVL::terrain::PTCH*>;
 	template class LIBSWBF2_API Types::List<LVL::terrain::VBUF*>;
 
@@ -534,9 +540,6 @@ namespace LibSWBF2
     template class LIBSWBF2_API Types::List<STR<"PRNT"_m> *>;
 
     template class LIBSWBF2_API Types::List<STRMULT<"ANIM"_m> *>;
-
-    template class LIBSWBF2_API Types::List<RawData<"POSK"_m> *>;
-    template class LIBSWBF2_API Types::List<RawData<"ROTK"_m> *>;
 
     template class LIBSWBF2_API Types::List<LVL::animation::TNOJ *>;
 
@@ -574,6 +577,7 @@ namespace LibSWBF2
 	template class LIBSWBF2_API Types::List<Wrappers::Terrain>;
 	template class LIBSWBF2_API Types::List<Wrappers::Instance>;
 	template class LIBSWBF2_API Types::List<Wrappers::Region>;
+	//template class LIBSWBF2_API Types::List<Wrappers::WorldAnimation>;
 	template class LIBSWBF2_API Types::List<Wrappers::Script>;
 	template class LIBSWBF2_API Types::List<Wrappers::Sound>;
 	template class LIBSWBF2_API Types::List<Wrappers::Localization>;

--- a/LibSWBF2/Types/WorldAnimationKey.cpp
+++ b/LibSWBF2/Types/WorldAnimationKey.cpp
@@ -1,0 +1,41 @@
+#include "pch.h"
+#include "Types/LibString.h"
+#include "FileReader.h"
+#include "FileWriter.h"
+#include <fmt/format.h>
+#include "WorldAnimationKey.h"
+#include "LibString.h"
+#include "Vector3.h"
+
+
+namespace LibSWBF2::Types
+{
+	void WorldAnimationKey::WriteToStream(FileWriter& stream)
+	{
+		stream.WriteFloat(m_Time);
+		m_Value.WriteToStream(stream);
+		stream.WriteByte((uint8_t) m_TransitionType);
+		m_EaseOut.WriteToStream(stream);
+		m_EaseIn.WriteToStream(stream);
+	}
+
+	void WorldAnimationKey::ReadFromStream(FileReader& stream)
+	{
+		m_Time = stream.ReadFloat();
+		m_Value.ReadFromStream(stream);
+		m_TransitionType = (EWorldAnimKeyTransitionType) stream.ReadByte();
+		m_EaseOut.ReadFromStream(stream);
+		m_EaseIn.ReadFromStream(stream);
+	}
+
+	String WorldAnimationKey::ToString() const
+	{
+		String rep = fmt::format("Time: {}, Value: {}, TransitionType: {}, EaseIn: {}, EaseOut: {}", 
+								m_Time, 
+								m_Value.ToString().Buffer(),
+								WorldAnimKeyTransitionTypeToString(m_TransitionType).Buffer(),
+								m_EaseOut.ToString().Buffer(),
+								m_EaseIn.ToString().Buffer()).c_str();
+		return rep;
+	}
+}

--- a/LibSWBF2/Types/WorldAnimationKey.h
+++ b/LibSWBF2/Types/WorldAnimationKey.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "req.h"
+
+
+namespace LibSWBF2
+{
+	class FileWriter;
+	class FileReader;
+}
+
+
+namespace LibSWBF2::Types
+{
+	struct Vector3;
+	struct String;
+
+	#pragma pack(push,1)
+	struct LIBSWBF2_API WorldAnimationKey
+	{
+		float_t m_Time;
+		Vector3 m_Value;
+		EWorldAnimKeyTransitionType m_TransitionType;
+		Vector3 m_EaseOut;
+		Vector3 m_EaseIn;
+
+		void WriteToStream(FileWriter& stream);
+		void ReadFromStream(FileReader& stream);
+
+		String ToString() const;
+
+	};
+	#pragma pack(pop)
+}

--- a/LibSWBF2/Wrappers/AnimationBank.cpp
+++ b/LibSWBF2/Wrappers/AnimationBank.cpp
@@ -330,21 +330,5 @@ namespace LibSWBF2::Wrappers
 
 		return decompStatus;
 	}
-
-
-	Curve<uint16_t> AnimationBank::GetCurve(CRCChecksum anim, CRCChecksum bone, ECurveType comp) const
-	{
-		List<uint16_t> inds;
-		List<float_t> values;
-
-		if (GetCurve(anim, bone, (uint32_t) comp, inds, values))
-		{
-			return Curve<uint16_t>(std::move(inds), std::move(values));
-		}
-		else 
-		{
-			LOG_THROW("AnimationBank {0}: Error decompressing curve for bone: 0x{1:x} of animation 0x{2:x}", GetName().Buffer(), bone, anim);
-		}
-	}
 }
 

--- a/LibSWBF2/Wrappers/AnimationBank.h
+++ b/LibSWBF2/Wrappers/AnimationBank.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Types/Enums.h"
-#include "Types/Curve.h"
 
 namespace LibSWBF2::Chunks::LVL::animation
 {
@@ -11,7 +10,6 @@ namespace LibSWBF2::Wrappers
 {
 	using Types::List;
 	using Types::String;
-	using Types::Curve;
 
 
 	class LIBSWBF2_API AnimationBank
@@ -27,11 +25,6 @@ namespace LibSWBF2::Wrappers
 
 		bool GetCurve(CRCChecksum anim, CRCChecksum bone, uint16_t component,
 					List<uint16_t> &frame_indices, List<float_t> &frame_values) const;
-
-		// Throws exception if <anim> isnt in the bank,
-		// or <bone> is not among <anim>'s bones, or if
-		// an error occurs during the decompression process.
-		Curve<uint16_t> GetCurve(CRCChecksum anim, CRCChecksum bone, ECurveType component) const;
 	
 		bool ContainsAnimation(CRCChecksum anim) const;
 

--- a/LibSWBF2/Wrappers/World.cpp
+++ b/LibSWBF2/Wrappers/World.cpp
@@ -131,14 +131,14 @@ namespace LibSWBF2::Wrappers
 		return p_WorldAnimationGroup -> p_Info -> m_Name;	
 	}
 
-	const bool WorldAnimationGroup::GetField1() const
+	const bool WorldAnimationGroup::IsPlayingAtStart() const
 	{
-		return p_WorldAnimationGroup -> p_Info -> m_0 == 1;
+		return p_WorldAnimationGroup -> p_Info -> m_PlayAtStart == 1;
 	}
 
-	const bool WorldAnimationGroup::GetField2() const
+	const bool WorldAnimationGroup::DisablesHierarchies() const
 	{
-		return p_WorldAnimationGroup -> p_Info -> m_1 == 1;
+		return p_WorldAnimationGroup -> p_Info -> m_DisableHierarchy == 1;
 	}
 
 	const void WorldAnimationGroup::GetAnimationInstancePairs(

--- a/LibSWBF2/Wrappers/World.cpp
+++ b/LibSWBF2/Wrappers/World.cpp
@@ -6,6 +6,7 @@
 #include "Container.h"
 
 #include "Chunks/LVL/wrld/wrld.h"
+#include "Chunks/LVL/wrld/anmg.INFO.h"
 
 
 namespace LibSWBF2::Wrappers
@@ -108,6 +109,56 @@ namespace LibSWBF2::Wrappers
 		}		
 		return AnimKeys;
 	}
+
+
+
+	// World Animation Group
+
+	bool WorldAnimationGroup::FromChunk(anmg* chunk, WorldAnimationGroup& groupOut)
+	{
+		if (chunk -> p_Info == nullptr)
+		{
+			return false;
+		}
+
+		groupOut.p_WorldAnimationGroup = chunk;
+		return true;
+	}
+
+	const String& WorldAnimationGroup::GetName() const
+	{
+		return p_WorldAnimationGroup -> p_Info -> m_Name;	
+	}
+
+	const bool WorldAnimationGroup::GetField1() const
+	{
+		return p_WorldAnimationGroup -> p_Info -> m_0 == 1;
+	}
+
+	const bool WorldAnimationGroup::GetField2() const
+	{
+		return p_WorldAnimationGroup -> p_Info -> m_1 == 1;
+	}
+
+	const void WorldAnimationGroup::GetAnimationInstancePairs(
+									List<String>& animNamesOut, 
+									List<String>& instanceNamesOut) const
+	{
+		animNamesOut.Clear();
+		instanceNamesOut.Clear();
+
+		for (uint16_t j = 0; j < p_WorldAnimationGroup -> m_AnimObjectPairs.Size(); j++)
+		{
+			auto& pair = p_WorldAnimationGroup -> m_AnimObjectPairs[j] -> m_Texts;
+			if (pair.Size() != 2)
+			{
+				continue;
+			}
+
+			animNamesOut.Add(pair[0]);
+			instanceNamesOut.Add(pair[1]);
+		}
+	}
 	
 
 
@@ -154,6 +205,16 @@ namespace LibSWBF2::Wrappers
 			}
 		}
 
+		List<anmg *>& animationGroups = worldChunk -> m_AnimationGroups;
+		for (size_t i = 0; i < animationGroups.Size(); ++i)
+		{
+			WorldAnimationGroup group;
+			if (WorldAnimationGroup::FromChunk(animationGroups[i], group))
+			{
+				out.m_AnimationGroups.Add(group);
+			}
+		}		
+
 		return true;
 	}
 
@@ -195,50 +256,5 @@ namespace LibSWBF2::Wrappers
 	const List<WorldAnimation>& World::GetAnimations() const
 	{
 		return m_Animations;
-	}
-	
-
-
-	const List<String> World::GetAnimationGroups() const
-	{
-		List<String> names;
-		const List<anmg*>& animGPtrs = p_World -> m_AnimationGroups;
-		for (uint16_t i = 0; i < animGPtrs.Size(); i++)
-		{
-			names.Add(animGPtrs[i] -> p_Info -> m_Text);
-		}
-		return names;	
-	}
-
-
-	const bool World::GetAnimationGroupPairs(const String& animGroupName, 
-									List<String>& animNamesOut, 
-									List<String>& instanceNamesOut) const
-	{
-		animNamesOut.Clear();
-		instanceNamesOut.Clear();
-
-		const List<anmg*>& animGPtrs = p_World -> m_AnimationGroups;
-		for (uint16_t i = 0; i < animGPtrs.Size(); i++)
-		{
-			if (animGroupName == animGPtrs[i] -> p_Info -> m_Text)
-			{
-				for (uint16_t j = 0; j < animGPtrs[i] -> m_AnimObjectPairs.Size(); j++)
-				{
-					auto& pair = animGPtrs[i] -> m_AnimObjectPairs[i] -> m_Texts;
-					if (pair.Size() != 2)
-					{
-						continue;
-					}
-
-					animNamesOut.Add(pair[0]);
-					instanceNamesOut.Add(pair[1]);
-				}
-
-				return true;
-			}
-		}
-
-		return false;
 	}
 }

--- a/LibSWBF2/Wrappers/World.cpp
+++ b/LibSWBF2/Wrappers/World.cpp
@@ -136,9 +136,14 @@ namespace LibSWBF2::Wrappers
 		return p_WorldAnimationGroup -> p_Info -> m_PlayAtStart == 1;
 	}
 
+	const bool WorldAnimationGroup::IsStoppedOnControl() const
+	{
+		return p_WorldAnimationGroup -> p_Info -> m_StopOnControl == 1;
+	}
+
 	const bool WorldAnimationGroup::DisablesHierarchies() const
 	{
-		return p_WorldAnimationGroup -> p_Info -> m_DisableHierarchy == 1;
+		return p_WorldAnimationGroup -> p_NoHierarchy != nullptr;
 	}
 
 	const void WorldAnimationGroup::GetAnimationInstancePairs(

--- a/LibSWBF2/Wrappers/World.cpp
+++ b/LibSWBF2/Wrappers/World.cpp
@@ -7,6 +7,7 @@
 
 #include "Chunks/LVL/wrld/wrld.h"
 #include "Chunks/LVL/wrld/anmg.INFO.h"
+#include "Chunks/LVL/wrld/anmh.INFO.h"
 
 
 namespace LibSWBF2::Wrappers
@@ -159,6 +160,31 @@ namespace LibSWBF2::Wrappers
 			instanceNamesOut.Add(pair[1]);
 		}
 	}
+
+
+
+	// World Animation Hierarchy
+
+	bool WorldAnimationHierarchy::FromChunk(anmh* chunk, WorldAnimationHierarchy& hierOut)
+	{
+		if (chunk -> p_Info == nullptr || chunk -> p_Info -> m_NumStrings == 0)
+		{
+			return false;
+		}
+
+		hierOut.p_WorldAnimationHierarchy = chunk;
+		return true;
+	}
+
+	const String& WorldAnimationHierarchy::GetRootName() const
+	{
+		return p_WorldAnimationHierarchy -> p_Info -> m_RootName;
+	}
+
+	const List<String>& WorldAnimationHierarchy::GetChildNames() const
+	{
+		return p_WorldAnimationHierarchy -> p_Info -> m_ChildNames;		
+	}
 	
 
 
@@ -215,6 +241,16 @@ namespace LibSWBF2::Wrappers
 			}
 		}		
 
+		List<anmh *>& animationHiers = worldChunk -> m_AnimationHierarchies;
+		for (size_t i = 0; i < animationHiers.Size(); ++i)
+		{
+			WorldAnimationHierarchy hier;
+			if (WorldAnimationHierarchy::FromChunk(animationHiers[i], hier))
+			{
+				out.m_AnimationHierarchies.Add(hier);
+			}
+		}
+
 		return true;
 	}
 
@@ -260,5 +296,10 @@ namespace LibSWBF2::Wrappers
 	const List<WorldAnimationGroup>& World::GetAnimationGroups() const
 	{
 		return m_AnimationGroups;
+	}
+
+	const List<WorldAnimationHierarchy>& World::GetAnimationHierarchies() const
+	{
+		return m_AnimationHierarchies;
 	}
 }

--- a/LibSWBF2/Wrappers/World.cpp
+++ b/LibSWBF2/Wrappers/World.cpp
@@ -251,10 +251,14 @@ namespace LibSWBF2::Wrappers
 	{
 		return p_World->p_SkyName != nullptr ? p_World->p_SkyName->m_Text : "";
 	}
-
 	
 	const List<WorldAnimation>& World::GetAnimations() const
 	{
 		return m_Animations;
+	}
+
+	const List<WorldAnimationGroup>& World::GetAnimationGroups() const
+	{
+		return m_AnimationGroups;
 	}
 }

--- a/LibSWBF2/Wrappers/World.cpp
+++ b/LibSWBF2/Wrappers/World.cpp
@@ -51,8 +51,64 @@ namespace LibSWBF2::Wrappers
 	{
 		return p_Region -> p_Info -> p_Type -> m_Text;
 	}
-	
 
+
+	// World Animation
+
+	bool WorldAnimation::FromChunk(anim* chunk, WorldAnimation& animOut)
+	{
+		if (chunk -> p_Info == nullptr)
+		{
+			return false;
+		}
+
+		animOut.p_WorldAnimation = chunk;
+		return true;
+	}
+
+	const String& WorldAnimation::GetName() const
+	{
+		return p_WorldAnimation -> p_Info -> m_Name;
+	}
+
+	const float WorldAnimation::GetRunTime() const
+	{
+		return p_WorldAnimation -> p_Info -> m_RunTime;
+	}
+
+
+	const bool WorldAnimation::IsLooping() const
+	{
+		return p_WorldAnimation -> p_Info -> m_Looping == 1;
+	}
+
+	const bool WorldAnimation::IsTranslationLocal() const
+	{
+		return p_WorldAnimation -> p_Info -> m_LocalTranslation == 1;
+	}
+
+	List<WorldAnimationKey> WorldAnimation::GetRotationKeys() const
+	{
+		List<WorldAnimationKey> AnimKeys;
+		for (int i = 0; i < p_WorldAnimation -> m_RotationKeys.Size(); i++)
+		{
+			ROTK *currKey = p_WorldAnimation -> m_RotationKeys[i];
+			AnimKeys.Add(currKey -> m_Key);
+		}	
+		return AnimKeys;	
+	}
+	
+	List<WorldAnimationKey> WorldAnimation::GetPositionKeys() const
+	{
+		List<WorldAnimationKey> AnimKeys;
+		for (int i = 0; i < p_WorldAnimation -> m_PositionKeys.Size(); i++)
+		{
+			POSK *currKey = p_WorldAnimation -> m_PositionKeys[i];
+			AnimKeys.Add(currKey -> m_Key);
+		}		
+		return AnimKeys;
+	}
+	
 
 
 	// World
@@ -86,7 +142,17 @@ namespace LibSWBF2::Wrappers
 			{
 				out.m_Regions.Add(region);
 			}
-		}		
+		}
+
+		List<anim *>& animations = worldChunk -> m_Animations;
+		for (size_t i = 0; i < animations.Size(); ++i)
+		{
+			WorldAnimation anim;
+			if (WorldAnimation::FromChunk(animations[i], anim))
+			{
+				out.m_Animations.Add(anim);
+			}
+		}
 
 		return true;
 	}
@@ -125,17 +191,12 @@ namespace LibSWBF2::Wrappers
 		return p_World->p_SkyName != nullptr ? p_World->p_SkyName->m_Text : "";
 	}
 
-
-	const List<String> World::GetAnimationNames() const
+	
+	const List<WorldAnimation>& World::GetAnimations() const
 	{
-		List<String> names;
-		const List<anim*>& animPtrs = p_World -> m_Animations;
-		for (uint16_t i = 0; i < animPtrs.Size(); i++)
-		{
-			names.Add(animPtrs[i] -> p_Info -> m_Text);
-		}
-		return names;
+		return m_Animations;
 	}
+	
 
 
 	const List<String> World::GetAnimationGroups() const
@@ -180,10 +241,4 @@ namespace LibSWBF2::Wrappers
 
 		return false;
 	}
-
-
-	//const Curve<float_t> World::GetAnimationCurve(const String& animName, ECurveType cc) const
-	//{
-	//	return Curve<float_t>();
-	//}
 }

--- a/LibSWBF2/Wrappers/World.h
+++ b/LibSWBF2/Wrappers/World.h
@@ -93,6 +93,7 @@ namespace LibSWBF2::Wrappers
 	public:
 		const String& GetName() const;
 		const bool IsPlayingAtStart() const;
+		const bool IsStoppedOnControl() const;
 		const bool DisablesHierarchies() const;
 		const void GetAnimationInstancePairs(List<String>& animNamesOut, List<String>& instanceNamesOut) const;
 	};

--- a/LibSWBF2/Wrappers/World.h
+++ b/LibSWBF2/Wrappers/World.h
@@ -6,7 +6,7 @@
 #include "Types/Vector3.h"
 #include "Types/Vector4.h"
 #include "Types/Enums.h"
-#include "Types/Curve.h"
+#include "Types/WorldAnimationKey.h"
 
 
 namespace LibSWBF2
@@ -17,6 +17,7 @@ namespace LibSWBF2
 	{
 		struct wrld;
 		struct regn;
+		struct anim;
 	}
 }
 
@@ -27,7 +28,7 @@ namespace LibSWBF2::Wrappers
 	using Types::String;
 	using Types::Vector3;
 	using Types::Vector4;
-	using Types::Curve;
+	using Types::WorldAnimationKey;
 
 	class Level;
 	class Instance;
@@ -54,6 +55,28 @@ namespace LibSWBF2::Wrappers
 		const Vector3& GetSize() const;
 	};
 
+	
+	class LIBSWBF2_API WorldAnimation
+	{
+	typedef LibSWBF2::Chunks::LVL::wrld::anim anim;
+
+		friend World;
+		friend List<WorldAnimation>;
+
+		anim* p_WorldAnimation;
+		WorldAnimation() = default;
+		static bool FromChunk(anim* chunk, WorldAnimation& animOut);		
+
+	public:
+		const String& GetName() const;
+		const float GetRunTime() const;
+		const bool IsLooping() const;
+		const bool IsTranslationLocal() const;
+		List<WorldAnimationKey> GetRotationKeys() const;
+		List<WorldAnimationKey> GetPositionKeys() const;
+	};
+
+
 
 	class LIBSWBF2_API World
 	{
@@ -70,6 +93,7 @@ namespace LibSWBF2::Wrappers
 
 		List<Instance> m_Instances;
 		List<Region> m_Regions;
+		List<WorldAnimation> m_Animations;
 
 		wrld* p_World;
 
@@ -85,19 +109,15 @@ namespace LibSWBF2::Wrappers
 		Types::String GetSkyName() const;
 
 
-		// Returns names of anims present 
-		const List<String> GetAnimationNames() const;
+		const List<WorldAnimation>& GetAnimations() const;
 
 		// Returns names of anim groups present
 		const List<String> GetAnimationGroups() const;
 
 		// Anim groups consist of pairs between instances and animations
-		// Returns false if <animGroup> not present
+		// Returns false if <animGroupName> not present
 		const bool GetAnimationGroupPairs(const String& animGroupName, 
 										List<String>& animNamesOut, 
 										List<String>& instanceNamesOut) const;
-
-		//Throws exception if <animName> is not among the anims present...
-		const Curve<float_t> GetAnimationCurve(const String& animName, ECurveType cc) const;
 	};
 }

--- a/LibSWBF2/Wrappers/World.h
+++ b/LibSWBF2/Wrappers/World.h
@@ -19,6 +19,7 @@ namespace LibSWBF2
 		struct regn;
 		struct anim;
 		struct anmg;
+		struct anmh;
 	}
 }
 
@@ -97,6 +98,22 @@ namespace LibSWBF2::Wrappers
 	};
 
 
+	class LIBSWBF2_API WorldAnimationHierarchy
+	{
+	typedef LibSWBF2::Chunks::LVL::wrld::anmh anmh;
+
+		friend World;
+		friend List<WorldAnimationHierarchy>;
+
+		anmh* p_WorldAnimationHierarchy;
+		WorldAnimationHierarchy() = default;
+		static bool FromChunk(anmh* chunk, WorldAnimationHierarchy& heirOut);		
+
+	public:
+		const String& GetRootName() const;
+		const List<String>& GetChildNames() const;
+	};
+
 
 	class LIBSWBF2_API World
 	{
@@ -115,7 +132,8 @@ namespace LibSWBF2::Wrappers
 		List<Region> m_Regions;
 		List<WorldAnimation> m_Animations;
 		List<WorldAnimationGroup> m_AnimationGroups;
-
+		List<WorldAnimationHierarchy> m_AnimationHierarchies;
+		
 		wrld* p_World;
 
 
@@ -131,5 +149,6 @@ namespace LibSWBF2::Wrappers
 
 		const List<WorldAnimation>& GetAnimations() const;
 		const List<WorldAnimationGroup>& GetAnimationGroups() const;
+		const List<WorldAnimationHierarchy>& GetAnimationHierarchies() const;
 	};
 }

--- a/LibSWBF2/Wrappers/World.h
+++ b/LibSWBF2/Wrappers/World.h
@@ -92,8 +92,8 @@ namespace LibSWBF2::Wrappers
 
 	public:
 		const String& GetName() const;
-		const bool GetField1() const;
-		const bool GetField2() const;
+		const bool IsPlayingAtStart() const;
+		const bool DisablesHierarchies() const;
 		const void GetAnimationInstancePairs(List<String>& animNamesOut, List<String>& instanceNamesOut) const;
 	};
 
@@ -133,7 +133,7 @@ namespace LibSWBF2::Wrappers
 		List<WorldAnimation> m_Animations;
 		List<WorldAnimationGroup> m_AnimationGroups;
 		List<WorldAnimationHierarchy> m_AnimationHierarchies;
-		
+
 		wrld* p_World;
 
 

--- a/LibSWBF2/Wrappers/World.h
+++ b/LibSWBF2/Wrappers/World.h
@@ -18,6 +18,7 @@ namespace LibSWBF2
 		struct wrld;
 		struct regn;
 		struct anim;
+		struct anmg;
 	}
 }
 
@@ -77,6 +78,25 @@ namespace LibSWBF2::Wrappers
 	};
 
 
+	class LIBSWBF2_API WorldAnimationGroup
+	{
+	typedef LibSWBF2::Chunks::LVL::wrld::anmg anmg;
+
+		friend World;
+		friend List<WorldAnimationGroup>;
+
+		anmg* p_WorldAnimationGroup;
+		WorldAnimationGroup() = default;
+		static bool FromChunk(anmg* chunk, WorldAnimationGroup& groupOut);		
+
+	public:
+		const String& GetName() const;
+		const bool GetField1() const;
+		const bool GetField2() const;
+		const void GetAnimationInstancePairs(List<String>& animNamesOut, List<String>& instanceNamesOut) const;
+	};
+
+
 
 	class LIBSWBF2_API World
 	{
@@ -94,6 +114,7 @@ namespace LibSWBF2::Wrappers
 		List<Instance> m_Instances;
 		List<Region> m_Regions;
 		List<WorldAnimation> m_Animations;
+		List<WorldAnimationGroup> m_AnimationGroups;
 
 		wrld* p_World;
 
@@ -108,16 +129,7 @@ namespace LibSWBF2::Wrappers
 		const Terrain* GetTerrain() const;
 		Types::String GetSkyName() const;
 
-
 		const List<WorldAnimation>& GetAnimations() const;
-
-		// Returns names of anim groups present
-		const List<String> GetAnimationGroups() const;
-
-		// Anim groups consist of pairs between instances and animations
-		// Returns false if <animGroupName> not present
-		const bool GetAnimationGroupPairs(const String& animGroupName, 
-										List<String>& animNamesOut, 
-										List<String>& instanceNamesOut) const;
+		const List<WorldAnimationGroup>& GetAnimationGroups() const;
 	};
 }


### PR DESCRIPTION
Finishes #31 
- added map anim (`anim`, `anmg`, `anmh`) chunks and corresponding `*.INFO`s
- C++ and C# wrappers + marshallers (`WorldAnimation`, `WorldAnimationGroup`,`WorldAnimationHierarchy`)
- `WorldAnimationKey` added as C++/C# `Type`, is automatically marshalled (e.g. like `VertexWeight` or `Vector*`)
- `LIB_NAME` changed to "SWBF2" to match "libSWBF2" for Unix as the runtime looks for "lib{LIB_NAME}" 
- Important bugfix in `BaseChunk::ThereIsAnother`.  Pretty minor change but since it's a very hot codepath I tested it a bunch of big levels and it's  fine as far as I can tell.