### PR TITLE
GetBoneCRCs fix

### DIFF
--- a/LibSWBF2/Wrappers/AnimationBank.cpp
+++ b/LibSWBF2/Wrappers/AnimationBank.cpp
@@ -242,32 +242,42 @@ namespace LibSWBF2::Wrappers
 	{
 		List<CRCChecksum> boneHashes;
 
-		MINA* metadata = p_AnimChunk->p_Bin->p_AnimsMetadata;
+		TNJA *index = p_AnimChunk -> p_Bin -> p_JointAddresses;
+		MINA *metadata = p_AnimChunk -> p_Bin -> p_AnimsMetadata;	
 
-		List<CRCChecksum>& animCRCs = metadata->m_AnimNameHashes;
 
-		int num_bones = -1;
-		for (int i = 0; i < animCRCs.Size(); i++)
+		List<CRCChecksum> &animCRCs = metadata -> m_AnimNameHashes;	
+
+		uint32_t TNJAOffset = 0;
+
+		bool foundAnim = false;
+
+		for (uint32_t i = 0; i < animCRCs.Size(); i++)
 		{
 			if (animCRCs[i] == animCRC)
 			{
-				num_bones = (uint32_t)metadata->m_AnimBoneCounts[i];
-				break;
+				foundAnim = true;
+
+				uint32_t num_bones = metadata -> m_AnimBoneCounts[i];
+
+				for (uint32_t j = 0; j < num_bones; j++)
+				{
+					CRCChecksum currCRC = index -> m_BoneCRCs[TNJAOffset + j];
+					if (!boneHashes.Contains(currCRC))
+					{
+						boneHashes.Add(currCRC);
+					}
+				}
+			}
+			else 
+			{
+				TNJAOffset += metadata -> m_AnimBoneCounts[i];
 			}
 		}
-		if (num_bones < 0)
-		{
-			LOG_WARN("Could not find animation metadata of animation 0x{0:x} in bank '{1}'", animCRC, p_AnimChunk->p_Name->m_Text.Buffer());
-			return boneHashes;
-		}
 
-		TNJA* index = p_AnimChunk->p_Bin->p_JointAddresses;
-		for (int i = 0; i < num_bones; i++)
+		if (!foundAnim)
 		{
-			// TODO: This returns bone duplicates!
-			// Maybe we have to index differently / somewhere else?
-			// Or maybe the reading is broken?
-			boneHashes.Add(index->m_BoneCRCs[i]);
+			LOG_WARN("Unable to get bones of missing animation 0x{0:x} in bank '{1}'", animCRC, p_AnimChunk->p_Name->m_Text.Buffer());
 		}
 
 		return boneHashes;


### PR DESCRIPTION
Briefly tested, ```GetBoneCRCs``` with ```human_sabre``` and ```human_sabre_sprint_full``` now returns the proper bone list without duplicates.  The duplicates are in the chunks themselves and I accounted for that in ```GetCurve```.  The bone CRC lists in ```TNJA``` have to be indexed via a per-anim offset, which I did in ```GetCurve``` but for some reason didn't in ```GetBoneCRC```s...